### PR TITLE
Update main.rs

### DIFF
--- a/core/tests/loadnext/src/main.rs
+++ b/core/tests/loadnext/src/main.rs
@@ -1,4 +1,4 @@
-//! Loadtest: an utility to stress-test the zkSync server.
+//! Loadtest: a utility to stress-test the zkSync server.
 //!
 //! In order to launch it, you must provide required environmental variables, for details see `README.md`.
 //! Without required variables provided, test is launched in the localhost/development mode with some hard-coded


### PR DESCRIPTION
In the comment at the top of the code snippet, there is a minor typo:

"Loadtest: an utility to stress-test the zkSync server." should be "Loadtest: a utility to stress-test the zkSync server." This is because 'utility' starts with a vowel sound, so 'a' should be used instead of 'an'. The use of "a" versus "an" before words that start with a vowel depends on the sound that follows, not just the vowel letter itself. The general rule is to use "an" before vowel sounds, not just vowels. This means that if the word starts with a vowel sound, you should use "an," and if it starts with a consonant sound, even if the first letter is a vowel, you should use "a."

Here are some examples to clarify:

Use "an" before a silent "h": "an hour"
Use "a" before a pronounced "u": "a university"
Use "a" before words like "one" and "European" because they begin with a 'y' sound: "a one-time event" or "a European country" So in the case of the word "utility," which starts with a 'y' sound, it is correct to use "a" and not "an." The corrected phrase is "a utility." ﻿